### PR TITLE
Fix initial build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include theos/makefiles/common.mk
+include $(theos)/makefiles/common.mk
 
 APPLICATION_NAME = crackMe2
 crackMe2_FILES = main.m ViewController.m

--- a/sudoapp.sh
+++ b/sudoapp.sh
@@ -1,7 +1,8 @@
 project=$(grep APPLICATION_NAME Makefile | awk '{print $3}')
 echo "creating root-permission script for: $project"
 
-target=_/DEBIAN/postinst
+mkdir DEBIAN && cd DEBIAN && touch postinst && cd ..
+target=DEBIAN/postinst
 cp sudoapp.template $target
 perl -p -i -e "s,<ProjectName>,$project,g" $target
 chmod 0555 $target

--- a/theos
+++ b/theos
@@ -1,1 +1,0 @@
-/Users/less/Codes/ios/jailbreak/theos


### PR DESCRIPTION
I changed the makefile, sudoapp.sh script, and removed the theos alias. Now, "make package" works the first time on the latest theos, with no changes to any files.

This assumes the user has $theos set in their bash_profile, which is more reliable than using an alias (the new theos installation instructions explicitly call for it).

It also resolves Issue #1 